### PR TITLE
ignore application config in local copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 
 # Ignore uploads.
 /public/uploads
+
+# Ignore application configuration
+/config/database.yml
+/config/secrets.yml


### PR DESCRIPTION
I think better to add these ignores in project level as well. Someone else may not be able to add them in their global ignore because they may not want to ignore in their other projects.